### PR TITLE
Make `design-token` Package Consumable Via ESM or CJS

### DIFF
--- a/packages/component-styles/.eslintrc.json
+++ b/packages/component-styles/.eslintrc.json
@@ -8,6 +8,10 @@
         "ecmaVersion": 12,
         "sourceType": "module"
     },
-    "rules": {
-    }
+    "globals": {
+        "require": true,
+        "__dirname": true,
+        "module": true
+    },
+    "rules": {}
 }

--- a/packages/component-styles/index.js
+++ b/packages/component-styles/index.js
@@ -1,0 +1,30 @@
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { buildDesignTokens } from "@x3r5e/design-tokens";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const platformsTest = [
+    {
+        name: "css",
+        destinationPath: `${resolve(__dirname, "./src/tokens")}/`,
+        destinationFilename: "variables.css",
+    },
+    {
+        name: "scss",
+        destinationPath: `${resolve(__dirname, "./src/tokens")}/`,
+        destinationFilename: "variables.scss",
+    },
+    {
+        name: "less",
+        destinationPath: `${resolve(__dirname, "./src/tokens")}/`,
+        destinationFilename: "variables.less",
+    },
+    {
+        name: "js",
+        destinationPath: `${resolve(__dirname, "./src/tokens")}/`,
+        destinationFilename: "variables.js",
+    },
+];
+
+buildDesignTokens(platformsTest);

--- a/packages/component-styles/package.json
+++ b/packages/component-styles/package.json
@@ -3,7 +3,6 @@
     "version": "0.3.0",
     "description": "",
     "main": "dist/index.js",
-    "type": "module",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/packages/component-styles/package.json
+++ b/packages/component-styles/package.json
@@ -1,24 +1,25 @@
 {
-  "name": "@x3r5e/component-styles",
-  "version": "0.3.0",
-  "description": "",
-  "main": "dist/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/danlevy1/example-design-system.git",
-    "directory": "packages/component-styles"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "keywords": [],
-  "author": "Daniel Levy (https://www.danlevy.info)",
-  "license": "MIT",
-  "gitHead": "75fb0674ebacb1e211e1c4b2329c567333de16bf",
-  "devDependencies": {
-    "eslint": "^7.12.0"
-  }
+    "name": "@x3r5e/component-styles",
+    "version": "0.3.0",
+    "description": "",
+    "main": "dist/index.js",
+    "type": "module",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/danlevy1/example-design-system.git",
+        "directory": "packages/component-styles"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "keywords": [],
+    "author": "Daniel Levy (https://www.danlevy.info)",
+    "license": "MIT",
+    "gitHead": "75fb0674ebacb1e211e1c4b2329c567333de16bf",
+    "devDependencies": {
+        "eslint": "^7.12.0"
+    }
 }

--- a/packages/component-styles/src/index.js
+++ b/packages/component-styles/src/index.js
@@ -1,8 +1,5 @@
-import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
-import { buildDesignTokens } from "@x3r5e/design-tokens";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const { resolve } = require("path");
+const { buildDesignTokens } = require("@x3r5e/design-tokens");
 
 const platformsTest = [
     {

--- a/packages/design-tokens/.eslintrc.json
+++ b/packages/design-tokens/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "env": {
-        "browser": true,
+        "browser": false,
         "es2021": true
     },
     "extends": "eslint:recommended",
@@ -10,8 +10,7 @@
     },
     "globals": {
         "require": true,
-        "__dirname": true,
-        "module": true
+        "__dirname": true
     },
     "rules": {}
 }

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -2,9 +2,11 @@
     "name": "@x3r5e/design-tokens",
     "version": "0.3.0",
     "description": "",
-    "main": "dist/properties.json",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "type": "module",
     "scripts": {
-        "build": "ts-node ./src/scripts/mergeProperties.ts && tsc --project tsconfig.prod.json",
+        "build": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/scripts/mergeProperties.ts && tsc --project tsconfig.prod.json",
         "prepublishOnly": "npm run build"
     },
     "repository": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "description": "",
     "main": "dist/cjs/index.js",
-    "types": "dist/index.d.ts",
+    "types": "dist/cjs/index.d.ts",
     "module": "./dist/esm/index.js",
     "files": [
         "dist/"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -2,11 +2,17 @@
     "name": "@x3r5e/design-tokens",
     "version": "0.3.0",
     "description": "",
-    "main": "dist/index.js",
+    "main": "dist/cjs/index.js",
     "types": "dist/index.d.ts",
-    "type": "module",
+    "module": "./dist/esm/index.js",
+    "files": [
+        "dist/"
+    ],
     "scripts": {
-        "build": "node --experimental-specifier-resolution=node --loader ts-node/esm ./src/scripts/mergeProperties.ts && tsc --project tsconfig.prod.json",
+        "build": "rm -rf ./dist && npm run merge-properties && npm run build:cjs && npm run build:esm",
+        "merge-properties": "ts-node ./src/scripts/mergeProperties.ts",
+        "build:cjs": "echo 'Building CommonJS format...' && tsc --project tsconfig.prod-cjs.json && echo 'Successfully built CommonJS format.'",
+        "build:esm": "echo 'Building ESModule format...' && tsc --project tsconfig.prod-esm.json && echo 'Successfully built ESModule format.'",
         "prepublishOnly": "npm run build"
     },
     "repository": {

--- a/packages/design-tokens/src/buildDesignTokens.ts
+++ b/packages/design-tokens/src/buildDesignTokens.ts
@@ -1,7 +1,4 @@
-import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const { resolve } = require("path");
 
 const PLATFORM_OPTIONS = new Map([
     ["css", "css/variables"],
@@ -24,7 +21,7 @@ interface StyleDictionaryConfig {
 }
 
 const styleDictionaryConfig: StyleDictionaryConfig = {
-    source: [resolve(__dirname, "properties.json")],
+    source: [resolve(__dirname, "../properties.json")],
     platforms: {},
 };
 
@@ -89,8 +86,7 @@ const buildDesignTokens = async (platforms: Platform[]) => {
         addPlatformToConfig(platform);
     });
 
-    const styleDictionaryModule = await import("style-dictionary");
-    const styleDictionary = styleDictionaryModule.default.extend(
+    const styleDictionary = require("style-dictionary").extend(
         styleDictionaryConfig
     );
 

--- a/packages/design-tokens/src/buildDesignTokens.ts
+++ b/packages/design-tokens/src/buildDesignTokens.ts
@@ -1,4 +1,7 @@
-const { resolve } = require("path");
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const PLATFORM_OPTIONS = new Map([
     ["css", "css/variables"],
@@ -80,17 +83,18 @@ const addPlatformToConfig = (platform: Platform) => {
  * Builds the design tokens for the specified platforms
  * @param platforms The platforms that the design tokens will be built for
  */
-const buildDesignTokens = (platforms: Platform[]) => {
+const buildDesignTokens = async (platforms: Platform[]) => {
     platforms.forEach((platform, index) => {
         validatePlatform(platform, index);
         addPlatformToConfig(platform);
     });
 
-    const StyleDictionary = require("style-dictionary").extend(
+    const styleDictionaryModule = await import("style-dictionary");
+    const styleDictionary = styleDictionaryModule.default.extend(
         styleDictionaryConfig
     );
 
-    StyleDictionary.registerTransformGroup({
+    styleDictionary.registerTransformGroup({
         name: "js",
         transforms: [
             "attribute/cti",
@@ -100,7 +104,7 @@ const buildDesignTokens = (platforms: Platform[]) => {
         ],
     });
 
-    StyleDictionary.buildAllPlatforms();
+    styleDictionary.buildAllPlatforms();
 };
 
-module.exports = buildDesignTokens;
+export default buildDesignTokens;

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,3 @@
+import buildDesignTokens from "./buildDesignTokens";
+
+export { buildDesignTokens };

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,3 +1,3 @@
-import buildDesignTokens from "./buildDesignTokens";
+import buildDesignTokens from "./buildDesignTokens.js";
 
 export { buildDesignTokens };

--- a/packages/design-tokens/src/scripts/mergeProperties.ts
+++ b/packages/design-tokens/src/scripts/mergeProperties.ts
@@ -34,6 +34,7 @@ const getFilePaths = async (directory: string): Promise<string[]> => {
                     console.warn(
                         `The following file was not added to the list because its extension is not ".json": ${directoryChildPath}`
                     );
+                    return null;
                 } else {
                     return directoryChildPath;
                 }
@@ -57,8 +58,12 @@ const mergePropertyFiles = async (): Promise<string> => {
     const filePaths = await getFilePaths(rootPropertiesDirectory);
 
     const files: object[] = filePaths.map((filePath) => {
-        const file = require(filePath);
-        return file;
+        if (filePath) {
+            const file = require(filePath);
+            return file;
+        }
+
+        return null;
     });
     const mergedProperties: object = merge.all(files);
     const mergedPropertiesString = JSON.stringify(mergedProperties);

--- a/packages/design-tokens/src/scripts/mergeProperties.ts
+++ b/packages/design-tokens/src/scripts/mergeProperties.ts
@@ -1,10 +1,6 @@
-// Package imports
-import { resolve, extname, dirname } from "path";
-import { readdir, stat, writeFile, mkdir } from "fs/promises";
-import { fileURLToPath } from "url";
-import merge from "deepmerge";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const { resolve, extname } = require("path");
+const { readdir, stat, writeFile, mkdir } = require("fs/promises");
+const merge = require("deepmerge");
 
 /**
  * Gets all files, including nested files, starting at the passed directory
@@ -60,13 +56,10 @@ const mergePropertyFiles = async (): Promise<string> => {
 
     const filePaths = await getFilePaths(rootPropertiesDirectory);
 
-    const files: object[] = await Promise.all(
-        filePaths.map(async (filePath) => {
-            const file = await import(filePath);
-            return file.default;
-        })
-    );
-
+    const files: object[] = filePaths.map((filePath) => {
+        const file = require(filePath);
+        return file;
+    });
     const mergedProperties: object = merge.all(files);
     const mergedPropertiesString = JSON.stringify(mergedProperties);
 

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "lib": ["ES2020"],
         "target": "ES2020",
         "module": "ESNext",
         "moduleResolution": "node",

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,13 +1,11 @@
 {
     "compilerOptions": {
         "lib": ["ES2020"],
-        "module": "commonjs",
-        "moduleResolution": "node",
         "target": "ES2020",
-        "noImplicitAny": true
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "noImplicitThis": true,
+        "esModuleInterop": true
     },
-    "files": [
-        "./src/scripts/buildDesignTokens.ts",
-        "./src/scripts/mergeProperties.ts"
-    ]
+    "include": ["./src/**/*.ts"]
 }

--- a/packages/design-tokens/tsconfig.prod-cjs.json
+++ b/packages/design-tokens/tsconfig.prod-cjs.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.prod-esm.json",
     "compilerOptions": {
+        "declaration": true,
         "module": "CommonJS",
         "outDir": "./dist/cjs"
     }

--- a/packages/design-tokens/tsconfig.prod-cjs.json
+++ b/packages/design-tokens/tsconfig.prod-cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.prod-esm.json",
+    "compilerOptions": {
+        "module": "CommonJS",
+        "outDir": "./dist/cjs"
+    }
+}

--- a/packages/design-tokens/tsconfig.prod-esm.json
+++ b/packages/design-tokens/tsconfig.prod-esm.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "declaration": true,
-        "outDir": "dist"
+        "outDir": "./dist/esm"
     },
     "exclude": ["./src/**/*.ts"],
     "files": ["./src/index.ts"]

--- a/packages/design-tokens/tsconfig.prod-esm.json
+++ b/packages/design-tokens/tsconfig.prod-esm.json
@@ -1,7 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
         "outDir": "./dist/esm"
     },
     "exclude": ["./src/**/*.ts"],

--- a/packages/design-tokens/tsconfig.prod.json
+++ b/packages/design-tokens/tsconfig.prod.json
@@ -4,5 +4,6 @@
         "declaration": true,
         "outDir": "dist"
     },
-    "files": ["./src/scripts/buildDesignTokens.ts"]
+    "exclude": ["./src/**/*.ts"],
+    "files": ["./src/index.ts"]
 }


### PR DESCRIPTION
Edited the design token package so that consumers can consume the package either using ESM or CommonJS.