### PR TITLE
Removed ESM Build

### DIFF
--- a/packages/design-tokens/package-lock.json
+++ b/packages/design-tokens/package-lock.json
@@ -677,25 +677,6 @@
         "resolve": "^1.17.0"
       }
     },
-    "@rollup/plugin-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
-      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.8"
-      }
-    },
-    "@rollup/plugin-replace": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
-      "integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      }
-    },
     "@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -3864,12 +3845,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "mock-fs": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
-      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5453,12 +5428,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
-      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -4,13 +4,11 @@
     "description": "",
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",
-    "module": "dist/index.mjs",
     "type": "commonjs",
     "files": [
         "dist/"
     ],
     "exports": {
-        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
         "default": "./dist/index.js"
     },
@@ -35,22 +33,17 @@
     "gitHead": "75fb0674ebacb1e211e1c4b2329c567333de16bf",
     "devDependencies": {
         "@rollup/plugin-commonjs": "^16.0.0",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-replace": "^2.3.4",
         "@types/jest": "^26.0.15",
         "@types/node": "^14.14.9",
         "chalk": "^4.1.0",
-        "deepmerge": "^4.2.2",
         "eslint": "^7.12.0",
         "jest": "^26.6.3",
-        "mock-fs": "^4.13.0",
         "rimraf": "^3.0.2",
         "rollup": "^2.33.3",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-copy": "^3.3.0",
         "rollup-plugin-delete": "^2.0.0",
-        "style-dictionary": "^3.0.0-rc.1",
-        "typescript": "^4.0.5"
+        "style-dictionary": "^3.0.0-rc.1"
     },
     "dependencies": {}
 }

--- a/packages/design-tokens/rollup.config.js
+++ b/packages/design-tokens/rollup.config.js
@@ -1,6 +1,4 @@
 import commonjs from "@rollup/plugin-commonjs";
-import json from "@rollup/plugin-json";
-import replace from "@rollup/plugin-replace";
 import copy from "rollup-plugin-copy";
 import del from "rollup-plugin-delete";
 import cleanup from "rollup-plugin-cleanup";
@@ -8,7 +6,12 @@ import pkg from "./package.json";
 
 const input = "src/index.js";
 const plugins = [
-    json(),
+    del({
+        targets: "dist/*",
+    }),
+    copy({
+        targets: [{ src: "src/properties", dest: "dist" }],
+    }),
     commonjs(),
     cleanup({ comments: "jsdoc", maxEmptyLines: 1, sourcemap: false }),
 ];
@@ -20,35 +23,12 @@ const external = [
     "url",
 ];
 
-export default [
-    {
-        input,
-        output: {
-            file: pkg.module,
-            format: "es",
-        },
-        plugins: [
-            // `del` and `copy` are the first plugins to run for the first file. It doesn't matter which file comes first though.
-            del({
-                targets: "dist/*",
-            }),
-            copy({
-                targets: [{ src: "src/properties", dest: "dist" }],
-            }),
-            replace({
-                __dirname: "dirname(fileURLToPath(import.meta.url))",
-            }),
-            ...plugins,
-        ],
-        external,
+export default {
+    input,
+    output: {
+        file: pkg.main,
+        format: "cjs",
     },
-    {
-        input,
-        output: {
-            file: pkg.main,
-            format: "cjs",
-        },
-        plugins,
-        external,
-    },
-];
+    plugins,
+    external,
+};

--- a/packages/design-tokens/src/buildDesignTokens/buildDesignTokens.js
+++ b/packages/design-tokens/src/buildDesignTokens/buildDesignTokens.js
@@ -1,9 +1,4 @@
-// dirname is used during the build process for the ESM output (see replace plugin in Rollup config)
-/* eslint-disable-next-line no-unused-vars */
-const { resolve, dirname } = require("path");
-// fileURLToPath is used during the build process for the ESM output (see replace plugin in Rollup config)
-/* eslint-disable-next-line no-unused-vars */
-const { fileURLToPath } = require("url");
+const { resolve } = require("path");
 const styleDictionary = require("style-dictionary");
 
 /**


### PR DESCRIPTION
There are still too many hoops to jump through in order to support ESModules in Node.js. The last problem that exists right now is that Jest does not currently fully support ESModules.

There are workarounds:
1. Use Jest's experimental ESM support. There are still problems with `import.meta.url` support when using TS + ESM + Jest.
2. Convert ESM syntax to CJS syntax using Rollup, and then run the tests. This has a large overhead and the Jest errors will point to the transpiled code. There might be a way to create a source map, but I haven't looked into it.

Rollup also doesn't fully support converting CJS to ESM (Rollup's main claim is converting ESM to CJS). The main CJS to ESM conversion problem is supporting `__dirname` in ESM. This is possible, but requires additional imports. There is no way to easily support this at the moment.